### PR TITLE
Remove __ASM macro

### DIFF
--- a/kernel/joel4/include/isr.h
+++ b/kernel/joel4/include/isr.h
@@ -84,7 +84,7 @@ void k_printRegs(regs_t* pRegs);
 #define _EOI_MASTER() outb(0x20, 0x20)
 #define _EOI_SLAVE()  outb(0xA0, 0x20)
 
-#define HALT() __ASM("hlt\n")
+#define HALT() asm("hlt\n")
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This macro is from KOS, and is no longer useful.
